### PR TITLE
chore(ci): :zap: add default docker platform to publish command

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
+COMPOSE_TAG='local-060225'
+
 MONGODB_USERNAME='root'
 MONGODB_ROOT_PASSWORD='your_password'
 MONGODB_PASSWORD='your_password'

--- a/.github/workflows/build-app-apk.yml
+++ b/.github/workflows/build-app-apk.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
     build:
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-22.04
         if: contains(github.event.head_commit.message, '[apk]')
         steps:
             - name: Setup repo

--- a/.github/workflows/build-push-docker.yml
+++ b/.github/workflows/build-push-docker.yml
@@ -11,6 +11,7 @@ on:
 env:
     DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
     DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
+    DOCKER_DEFAULT_PLATFORM: linux/amd64
 
 jobs:
     check-skip:
@@ -68,54 +69,42 @@ jobs:
               id: set_short_sha
               run: echo "SHORT_SHA=$(echo ${{ github.sha }} | cut -c 1-7)" >> $GITHUB_OUTPUT
 
-            - name: Create .env file
+            - name: Create .env files
               run: |
-                  touch .env
-                  echo "# .env created" >> .env
-                  echo "# .env created" >> ./apps/fe/.env
-                  echo "# .env created" >> ./apps/mnt/.env
-                  echo "# .env created" >> ./apps/api/.env
-                  echo "# .env created" >> ./containers/be-with-redis/.env
-                  echo "# .env created" >> ./containers/be-redis-pm2/.env
-                  echo "# .env created" >> ./containers/be-redis-es/.env
-                  cat .env
+                  for dir in "." "apps/fe" "apps/mnt" "apps/api" "containers/be-with-redis" "containers/be-redis-pm2" "containers/be-redis-es"; do
+                    echo "# .env created" > "$dir/.env"
+                  done
 
             - name: Prepare env for fe and mnt
               run: |
-                  echo "NEXT_PUBLIC_API_URL='https://api.vephim.online'" >> ./apps/fe/.env
-                  echo "NEXT_PUBLIC_IMAGES_URL='https://img.vephim.online'" >> ./apps/fe/.env
-                  echo "NEXT_SHARP_PATH='/usr/src/app/node_modules/sharp'" >> ./apps/fe/.env
+                  for dir in "apps/fe" "apps/mnt"; do
+                    echo "NEXT_PUBLIC_API_URL='https://api.vephim.online'" >> "$dir/.env"
+                    echo "NEXT_PUBLIC_IMAGES_URL='https://img.vephim.online'" >> "$dir/.env"
+                    echo "NEXT_SHARP_PATH='/usr/src/app/node_modules/sharp'" >> "$dir/.env"
+                  done
                   echo "NEXT_PUBLIC_TMDB_API_KEY=${{ secrets.TMDB_API_KEY }}" >> ./apps/fe/.env
                   echo "NEXT_PUBLIC_GOOGLE_ANALYTICS_ID=${{ secrets.NEXT_PUBLIC_GOOGLE_ANALYTICS_ID }}" >> ./apps/fe/.env
 
-                  echo "NEXT_PUBLIC_API_URL='https://api.vephim.online'" >> ./apps/mnt/.env
-                  echo "NEXT_PUBLIC_IMAGES_URL='https://img.vephim.online'" >> ./apps/mnt/.env
-                  echo "NEXT_SHARP_PATH='/usr/src/app/node_modules/sharp'" >> ./apps/mnt/.env
+            - name: Build and push Docker images
+              id: docker_build_push
+              run: |
+                function build_and_push() {
+                  local compose_file="$1"
+                  $DOCKER_DEFAULT_PLATFORM docker compose -f "$compose_file" build
+                  $DOCKER_DEFAULT_PLATFORM docker compose -f "$compose_file" push
+                }
 
-            - name: Set COMPOSE_TAG as short commit SHA
-              id: set_compose_tag
-              run: dotenvx set --plain COMPOSE_TAG ${{ steps.set_short_sha.outputs.SHORT_SHA }}
+                # Build and push with short SHA tag
+                dotenvx set --plain COMPOSE_TAG ${{ steps.set_short_sha.outputs.SHORT_SHA }}
+                build_and_push "docker-compose.yml"
+                build_and_push "docker-compose.bundle.yml"
 
-            - name: Build and push images with short commit SHA tag
-              id: build_push_images
-              run: DOCKER_DEFAULT_PLATFORM=linux/amd64 docker compose -f docker-compose.yml build && DOCKER_DEFAULT_PLATFORM=linux/amd64 docker compose -f docker-compose.yml push
-
-            - name: Build and push bundle images
-              id: build_push_bundle
-              if: ${{ success() && steps.build_push_images.outcome == 'success' }}
-              run: DOCKER_DEFAULT_PLATFORM=linux/amd64 docker compose -f docker-compose.bundle.yml build && DOCKER_DEFAULT_PLATFORM=linux/amd64 docker compose -f docker-compose.bundle.yml push
-
-            - name: Set COMPOSE_TAG as latest
-              if: contains(needs.check-skip.outputs.commit_message, '[docker-latest]')
-              run: dotenvx set --plain COMPOSE_TAG latest
-
-            - name: Build and push images with latest tag
-              if: contains(needs.check-skip.outputs.commit_message, '[docker-latest]')
-              run: DOCKER_DEFAULT_PLATFORM=linux/amd64 docker compose -f docker-compose.yml build && DOCKER_DEFAULT_PLATFORM=linux/amd64 docker compose -f docker-compose.yml push
-
-            - name: Build and push bundle images with latest tag
-              if: contains(needs.check-skip.outputs.commit_message, '[docker-latest]')
-              run: DOCKER_DEFAULT_PLATFORM=linux/amd64 docker compose -f docker-compose.bundle.yml build && DOCKER_DEFAULT_PLATFORM=linux/amd64 docker compose -f docker-compose.bundle.yml push
+                # Build and push with latest tag if specified
+                if [[ "${{ needs.check-skip.outputs.commit_message }}" =~ "[docker-latest]" ]]; then
+                  dotenvx set --plain COMPOSE_TAG latest
+                  build_and_push "docker-compose.yml"
+                  build_and_push "docker-compose.bundle.yml"
+                fi
 
             - name: Remove .env file
               run: rm .env

--- a/.github/workflows/build-push-docker.yml
+++ b/.github/workflows/build-push-docker.yml
@@ -6,7 +6,7 @@ on:
     #     types: completed
     #     branches: [main]
     push:
-        branches: ['main', 'fix/docker-with-actions']
+        branches: ['main']
 
 env:
     DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -15,7 +15,7 @@ env:
 jobs:
     check-skip:
         # if: ${{ github.event.workflow_run.conclusion == 'success' }}
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-22.04
         outputs:
             commit_message: ${{ steps.get_commit_message.outputs.commit_message }}
             skip_docker: ${{ steps.check_skip_docker.outputs.skip_docker }}
@@ -45,7 +45,7 @@ jobs:
     build:
         needs: [check-skip]
         if: ${{ needs.check-skip.outputs.skip_docker != 'true' }}
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout code
               uses: actions/checkout@v4

--- a/.github/workflows/build-push-docker.yml
+++ b/.github/workflows/build-push-docker.yml
@@ -6,8 +6,7 @@ on:
     #     types: completed
     #     branches: [main]
     push:
-        branches:
-            - main
+        branches: ['main', 'fix/docker-with-actions']
 
 env:
     DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -99,12 +98,12 @@ jobs:
 
             - name: Build and push images with short commit SHA tag
               id: build_push_images
-              run: DOCKER_DEFAULT_PLATFORM=linux/amd64 docker compose -f docker-compose.yml build && docker compose -f docker-compose.yml push
+              run: DOCKER_DEFAULT_PLATFORM=linux/amd64 docker compose -f docker-compose.yml build && DOCKER_DEFAULT_PLATFORM=linux/amd64 docker compose -f docker-compose.yml push
 
             - name: Build and push bundle images
               id: build_push_bundle
               if: ${{ success() && steps.build_push_images.outcome == 'success' }}
-              run: DOCKER_DEFAULT_PLATFORM=linux/amd64 docker compose -f docker-compose.bundle.yml build && docker compose -f docker-compose.bundle.yml push
+              run: DOCKER_DEFAULT_PLATFORM=linux/amd64 docker compose -f docker-compose.bundle.yml build && DOCKER_DEFAULT_PLATFORM=linux/amd64 docker compose -f docker-compose.bundle.yml push
 
             - name: Set COMPOSE_TAG as latest
               if: contains(needs.check-skip.outputs.commit_message, '[docker-latest]')
@@ -112,11 +111,11 @@ jobs:
 
             - name: Build and push images with latest tag
               if: contains(needs.check-skip.outputs.commit_message, '[docker-latest]')
-              run: DOCKER_DEFAULT_PLATFORM=linux/amd64 docker compose -f docker-compose.yml build && docker compose -f docker-compose.yml push
+              run: DOCKER_DEFAULT_PLATFORM=linux/amd64 docker compose -f docker-compose.yml build && DOCKER_DEFAULT_PLATFORM=linux/amd64 docker compose -f docker-compose.yml push
 
             - name: Build and push bundle images with latest tag
               if: contains(needs.check-skip.outputs.commit_message, '[docker-latest]')
-              run: DOCKER_DEFAULT_PLATFORM=linux/amd64 docker compose -f docker-compose.bundle.yml build && docker compose -f docker-compose.bundle.yml push
+              run: DOCKER_DEFAULT_PLATFORM=linux/amd64 docker compose -f docker-compose.bundle.yml build && DOCKER_DEFAULT_PLATFORM=linux/amd64 docker compose -f docker-compose.bundle.yml push
 
             - name: Remove .env file
               run: rm .env

--- a/.github/workflows/nx-ci.yml
+++ b/.github/workflows/nx-ci.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
     main:
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-22.04
         steps:
             - uses: actions/checkout@v4
               with:


### PR DESCRIPTION
## Summary by Sourcery

Set the default docker platform to linux/amd64 when building and pushing images.

Enhancements:
- Add "fix/docker-with-actions" branch to the list of branches that trigger the docker build workflow.

CI:
- Set DOCKER_DEFAULT_PLATFORM=linux/amd64 for all docker compose commands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the automated container deployment process to use a single string format for branch triggers.
  - Enhanced deployment consistency by enforcing platform settings during image push operations.
  - Cleaned up outdated configurations to maintain clarity and reliability in the deployment workflow.
  - Updated the build environment for Docker, Android App APK, and CI jobs to use a newer version of Ubuntu.
  - Added a new environment variable `COMPOSE_TAG` for improved configuration management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->